### PR TITLE
Allow configuring a default processing tier for creating accountholders

### DIFF
--- a/src/main/java/com/adyen/mirakl/config/ApplicationProperties.java
+++ b/src/main/java/com/adyen/mirakl/config/ApplicationProperties.java
@@ -48,6 +48,7 @@ public class ApplicationProperties {
     private Map<String, String> houseNumbersRegex;
     private String basicUsername;
     private String basicPassword;
+    private Integer defaultProcessingTier;
 
     @Bean
     public Map<String, Pattern> houseNumberPatterns() {
@@ -142,5 +143,13 @@ public class ApplicationProperties {
 
     public void setRetryDocsCron(final String retryDocsCron) {
         this.retryDocsCron = retryDocsCron;
+    }
+
+    public Integer getDefaultProcessingTier() {
+        return defaultProcessingTier;
+    }
+
+    public void setDefaultProcessingTier(final Integer defaultProcessingTier) {
+        this.defaultProcessingTier = defaultProcessingTier;
     }
 }

--- a/src/main/java/com/adyen/mirakl/service/ShopService.java
+++ b/src/main/java/com/adyen/mirakl/service/ShopService.java
@@ -26,7 +26,6 @@ import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -41,6 +40,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
+import com.adyen.mirakl.config.ApplicationProperties;
 import com.adyen.mirakl.domain.StreetDetails;
 import com.adyen.mirakl.service.util.IsoUtil;
 import com.adyen.mirakl.service.util.MiraklDataExtractionUtil;
@@ -68,7 +68,6 @@ import com.adyen.model.marketpay.notification.CompensateNegativeBalanceNotificat
 import com.adyen.service.Account;
 import com.adyen.service.exception.ApiException;
 import com.mirakl.client.mmp.domain.common.MiraklAdditionalFieldValue;
-import com.mirakl.client.mmp.domain.common.country.IsoCountryCode;
 import com.mirakl.client.mmp.domain.shop.MiraklContactInformation;
 import com.mirakl.client.mmp.domain.shop.MiraklShop;
 import com.mirakl.client.mmp.domain.shop.MiraklShops;
@@ -88,6 +87,9 @@ import com.mirakl.client.mmp.request.shop.MiraklGetShopsRequest;
 public class ShopService {
 
     private final Logger log = LoggerFactory.getLogger(ShopService.class);
+
+    @Resource
+    private ApplicationProperties applicationProperties;
 
     @Resource
     private MiraklMarketplacePlatformOperatorApiClient miraklMarketplacePlatformOperatorApiClient;
@@ -246,6 +248,10 @@ public class ShopService {
         MiraklContactInformation contactInformation = getContactInformationFromShop(shop);
         accountHolderDetails.setEmail(contactInformation.getEmail());
         createAccountHolderRequest.setAccountHolderDetails(accountHolderDetails);
+
+        if (applicationProperties.getDefaultProcessingTier() != null) {
+            createAccountHolderRequest.setProcessingTier(applicationProperties.getDefaultProcessingTier());
+        }
 
         return createAccountHolderRequest;
     }

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -123,6 +123,7 @@ application:
         NL: "\\s([a-zA-Z]*\\d+[a-zA-Z]*)$"
     basicUsername: ${NOTIFY_USERNAME}
     basicPassword: ${NOTIFY_PASSWORD}
+    defaultProcessingTier: null
 
 miraklOperator:
     miraklEnvUrl: ${MIRAKL_ENV_URL}

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -110,6 +110,7 @@ application:
         NL: "\\s([a-zA-Z]*\\d+[a-zA-Z]*)$"
     basicUsername: test
     basicPassword: test
+    defaultProcessingTier: null
 
 shops:
     shopIds:


### PR DESCRIPTION
This will allow for bumping all accountholders to the required processing tier and start KYC verification.

It only affects newly created accountholders; we don't update the processing tier on existing accountholders.

Configuration is done through the application.yml (default value is `null` to not change the current behaviour):

```yml
application:
    defaultProcessingTier: 1
```