### PR TITLE
Don't retry payout after HTTP 500 (Internal Server Error) response

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
     repositories {
         mavenLocal()
         jcenter()
-        maven { url "http://repo.spring.io/plugins-release" }
+        maven { url "https://repo.spring.io/plugins-release" }
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {

--- a/src/test/java/com/adyen/mirakl/service/PayoutServiceTest.java
+++ b/src/test/java/com/adyen/mirakl/service/PayoutServiceTest.java
@@ -187,6 +187,7 @@ public class PayoutServiceTest {
         miraklVoucherEntry.setCurrencyIsoCode("EUR");
         payoutService.processMiraklVoucherEntry(miraklVoucherEntry);
 
-        verify(adyenPayoutErrorRepository).save(isA(AdyenPayoutError.class));
+        // We shouldn't retry on HTTP 500 (Internal Server Error) from Adyen
+        verify(adyenPayoutErrorRepository, never()).save(any(AdyenPayoutError.class));
     }
 }


### PR DESCRIPTION
Adyen will retry those requests automatically, and therefore the Mirakl connector should not (otherwise, payouts might happen twice).